### PR TITLE
Update travis-ci with some linting and reformat with clang-format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - cppcheck
       - clang
       - clang-tidy
+      - python3
 script:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get update -q
@@ -15,6 +16,7 @@ script:
   - arm-none-eabi-gcc --version
   - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake -G "Ninja"
   - ninja
+  - python3 scripts/task_stack.py
   - cppcheck src/
   - for f in src/**/*.cpp; do clang-format $f | diff -u $f -; done
   - ./analyze.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ addons:
   apt:
     packages:
       - cmake
+      - ninja-build
+      - cppcheck
 script:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get update -q
   - sudo apt-get install gcc-arm-embedded -y
   - arm-none-eabi-gcc --version
-  - ./boot.sh
-  - make
+  - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake -G "Ninja"
+  - ninja
+  - cppcheck src/
+  - for f in src/**/*.cpp; do clang-format $f | diff -u $f -; done
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - cmake
       - ninja-build
       - cppcheck
+      - clang
 script:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get update -q
@@ -15,4 +16,4 @@ script:
   - ninja
   - cppcheck src/
   - for f in src/**/*.cpp; do clang-format $f | diff -u $f -; done
-
+  - ./analyze.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - ninja-build
       - cppcheck
       - clang
+      - clang-tidy
 script:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get update -q

--- a/analyze.sh
+++ b/analyze.sh
@@ -1,16 +1,13 @@
 #!/bin/sh
 
+set -e
+./clean.sh
+
 export CCC_CC=clang
 export CCC_CXX=clang++
 
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
-      -DCMAKE_TOOLCHAIN_FILE=./cmake/static.cmake .
-
-# reformat our source code
-clang-format -style=file -i src/**/*.cpp src/**/*.h src/**/*.c
+      -DCMAKE_TOOLCHAIN_FILE=./cmake/static.cmake -G Ninja .
 
 # run the linter
-clang-tidy src/*
-
-# run the static analyzer
-scan-build make -j4
+clang-tidy src/**/*.cpp src/**/*.h

--- a/analyze.sh
+++ b/analyze.sh
@@ -11,5 +11,3 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
 
 # run the linter
 clang-tidy src/**/*.cpp
-
-python3 scripts/task_stack.py

--- a/analyze.sh
+++ b/analyze.sh
@@ -10,4 +10,4 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
       -DCMAKE_TOOLCHAIN_FILE=./cmake/static.cmake -G Ninja .
 
 # run the linter
-clang-tidy src/**/*.cpp src/**/*.h
+clang-tidy src/**/*.cpp

--- a/analyze.sh
+++ b/analyze.sh
@@ -11,3 +11,5 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
 
 # run the linter
 clang-tidy src/**/*.cpp
+
+python3 scripts/task_stack.py

--- a/clean.sh
+++ b/clean.sh
@@ -7,6 +7,12 @@ then
     rm Makefile
 fi
 
+if [ -f build.ninja ]
+then
+    ninja clean
+    rm -f build.ninja rules.ninja .ninja_deps .ninja_log
+fi
+
 # delete cmake's mess
 if [ -f CMakeCache.txt ]
 then

--- a/cmake/gcc.cmake
+++ b/cmake/gcc.cmake
@@ -13,7 +13,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(FLAGS_COMMON "-mthumb -mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -fdata-sections -ffunction-sections -Wall -g3" CACHE INTERNAL "C / C++ common Flags")
+set(FLAGS_COMMON "-fstack-usage -mthumb -mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -fdata-sections -ffunction-sections -Wall -g3" CACHE INTERNAL "C / C++ common Flags")
 set(FLAGS_CXX "-std=c++17 -Wno-register -fno-unwind-tables -fno-exceptions -fno-rtti" CACHE INTERNAL "C++ only Flags")
 set(FLAGS_C "" CACHE INTERNAL "C only Flags")
 set(FLAGS_LINKER "-Wl,--gc-sections --specs=nano.specs -Tmem.ld -lc -lm -lnosys -Wl,-Map=bin/${CMAKE_PROJECT_NAME}.map" CACHE INTERNAL "Linker flags")

--- a/cmake/static.cmake
+++ b/cmake/static.cmake
@@ -13,8 +13,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-include_directories("/usr/arm-none-eabi/include/c++/9.1.0")
-include_directories("/usr/arm-none-eabi/include/c++/9.1.0/arm-none-eabi")
+include_directories("/usr/arm-none-eabi/include/c++/7.3.1")
+include_directories("/usr/arm-none-eabi/include/c++/7.3.1/arm-none-eabi")
 
 set(FLAGS_COMMON "-target armv7em-none-eabihf -I/usr/arm-none-eabi/include" CACHE INTERNAL "C / C++ common Flags")
 set(FLAGS_CXX "-std=c++17 -Wno-register -fno-unwind-tables -fno-exceptions -fno-rtti" CACHE INTERNAL "C++ only Flags")

--- a/cmake/static.cmake
+++ b/cmake/static.cmake
@@ -1,8 +1,8 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-set(CMAKE_C_COMPILER /usr/lib/clang/ccc-analyzer)
-set(CMAKE_CXX_COMPILER /usr/lib/clang/c++-analyzer)
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang)
 set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
 set(CMAKE_SIZE llvm-size)
 

--- a/cmake/static.cmake
+++ b/cmake/static.cmake
@@ -13,13 +13,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/../../../../arm-none-eabi/include/c++/8.3.0")
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/../../../../arm-none-eabi/include/c++/8.3.0/arm-none-eabi")
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/../../../../arm-none-eabi/include/c++/8.3.0/backward")
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/include")
-
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/include-fixed")
-include_directories("/usr/lib/gcc/arm-none-eabi/8.3.0/../../../../arm-none-eabi/include")
+include_directories("/usr/arm-none-eabi/include/c++/9.1.0")
+include_directories("/usr/arm-none-eabi/include/c++/9.1.0/arm-none-eabi")
 
 set(FLAGS_COMMON "-target armv7em-none-eabihf -I/usr/arm-none-eabi/include" CACHE INTERNAL "C / C++ common Flags")
 set(FLAGS_CXX "-std=c++17 -Wno-register -fno-unwind-tables -fno-exceptions -fno-rtti" CACHE INTERNAL "C++ only Flags")

--- a/scripts/task_stack.py
+++ b/scripts/task_stack.py
@@ -7,26 +7,27 @@ import sys
 from re import findall
 from pathlib import Path
 
-print(f'{"task":10}{"allocated":>15}{"used":>15}')
+print('{:10}{:>15}{:>15}'.format('task', 'allocated', 'used'))
 print('----------------------------------------')
 
 tasks = []
 
 # lmao what is this
 for filename in Path('src').glob('**/*.cpp'):
+    filename = str(filename)
     with open(filename, 'r') as f:
         s = f.read()
         toks = findall(r"[\w']+|[.,!?;]", s)
         for i, t in enumerate(toks):
             if t == 'StaticTask':
                 used = None
-                with open(f'CMakeFiles/csdc5-a.elf.dir/{filename}.su') as suf:
+                with open('CMakeFiles/csdc5-a.elf.dir/{}.su'.format(filename)) as suf:
                     sut = suf.readlines()
                     stoks = map(lambda s: findall(r"[\w\.]+", s), sut)
                     for su in stoks:
                         if toks[i+7] == su[4]:
                             if su[-1] != 'static':
-                                print(f'task {toks[i+2]} does not use a static stack size')
+                                print('task {} does not use a static stack size'.format(toks[i+2]))
                                 exit(1)
                             used = int(su[-2])
                 tasks.append({'name': toks[i+2],
@@ -37,7 +38,7 @@ for filename in Path('src').glob('**/*.cpp'):
 
 failed = False
 for t in tasks:
-    print(f'{t["name"]:10}{t["alloc"]:>15}{t["used"]:>15}')
+    print('{:10}{:>15}{:>15}'.format(t["name"], t["alloc"], t["used"]))
     if (t["alloc"] < t["used"]):
         failed = True
 

--- a/scripts/task_stack.py
+++ b/scripts/task_stack.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Script that extracts the 'StaticTask's in use, and then makes sure
+# they don't exceed their statically-allocated stack usage.
+
+import sys
+from re import findall
+from pathlib import Path
+
+print(f'{"task":10}{"allocated":>15}{"used":>15}')
+print('----------------------------------------')
+
+tasks = []
+
+# lmao what is this
+for filename in Path('src').glob('**/*.cpp'):
+    with open(filename, 'r') as f:
+        s = f.read()
+        toks = findall(r"[\w']+|[.,!?;]", s)
+        for i, t in enumerate(toks):
+            if t == 'StaticTask':
+                used = None
+                with open(f'CMakeFiles/csdc5-a.elf.dir/{filename}.su') as suf:
+                    sut = suf.readlines()
+                    stoks = map(lambda s: findall(r"[\w\.]+", s), sut)
+                    for su in stoks:
+                        if toks[i+7] == su[4]:
+                            if su[-1] != 'static':
+                                print(f'task {toks[i+2]} does not use a static stack size')
+                                exit(1)
+                            used = int(su[-2])
+                tasks.append({'name': toks[i+2],
+                              'alloc': int(toks[i+1]) * 4,
+                              'func': toks[i+7],
+                              'file': filename,
+                              'used': used})
+
+failed = False
+for t in tasks:
+    print(f'{t["name"]:10}{t["alloc"]:>15}{t["used"]:>15}')
+    if (t["alloc"] < t["used"]):
+        failed = True
+
+if failed:
+    exit(2)

--- a/src/hardware/gpio.cpp
+++ b/src/hardware/gpio.cpp
@@ -6,22 +6,22 @@
  * @param port The register block pointing to the GPIO port.
  */
 GPIOPort::GPIOPort(Port port)
-    : port(port), pin_states({{*this, 0},
-                              {*this, 1},
-                              {*this, 2},
-                              {*this, 3},
-                              {*this, 4},
-                              {*this, 5},
-                              {*this, 6},
-                              {*this, 7},
-                              {*this, 8},
-                              {*this, 9},
-                              {*this, 10},
-                              {*this, 11},
-                              {*this, 12},
-                              {*this, 13},
-                              {*this, 14},
-                              {*this, 15}}),
+    : port(port), pin_states({{{*this, 0},
+                               {*this, 1},
+                               {*this, 2},
+                               {*this, 3},
+                               {*this, 4},
+                               {*this, 5},
+                               {*this, 6},
+                               {*this, 7},
+                               {*this, 8},
+                               {*this, 9},
+                               {*this, 10},
+                               {*this, 11},
+                               {*this, 12},
+                               {*this, 13},
+                               {*this, 14},
+                               {*this, 15}}}),
       regs((GPIO_TypeDef *)((port * 0x400) + (uint32_t)GPIOA)) {}
 
 /**

--- a/src/hardware/gpio.cpp
+++ b/src/hardware/gpio.cpp
@@ -5,42 +5,45 @@
  *
  * @param port The register block pointing to the GPIO port.
  */
-GPIOPort::GPIOPort(Port port): port(port),
-    pin_states({
-        { *this, 0 }, { *this, 1 }, { *this, 2 }, { *this, 3 },
-        { *this, 4 }, { *this, 5 }, { *this, 6 }, { *this, 7 },
-        { *this, 8 }, { *this, 9 }, { *this, 10 }, { *this, 11 },
-        { *this, 12 }, { *this, 13 }, { *this, 14 }, { *this, 15 }
-    }),
-    regs((GPIO_TypeDef *)((port * 0x400) + (uint32_t)GPIOA))
-{}
+GPIOPort::GPIOPort(Port port)
+    : port(port), pin_states({{*this, 0},
+                              {*this, 1},
+                              {*this, 2},
+                              {*this, 3},
+                              {*this, 4},
+                              {*this, 5},
+                              {*this, 6},
+                              {*this, 7},
+                              {*this, 8},
+                              {*this, 9},
+                              {*this, 10},
+                              {*this, 11},
+                              {*this, 12},
+                              {*this, 13},
+                              {*this, 14},
+                              {*this, 15}}),
+      regs((GPIO_TypeDef *)((port * 0x400) + (uint32_t)GPIOA)) {}
 
 /**
  * @brief Get a pin object from the GPIO port.
- * 
+ *
  * @param pin The pin number to get access to.
  */
-GPIOPin GPIOPort::get_pin(uint32_t pin) {
-    return GPIOPin(pin_states[pin]);
-}
+GPIOPin GPIOPort::get_pin(uint32_t pin) { return GPIOPin(pin_states[pin]); }
 
 /**
  * @brief Power on the GPIO port hardware.
  */
-void GPIOPort::init() {
-    SET_BIT(RCC->AHB4ENR, 1 << port);
-}
+void GPIOPort::init() { SET_BIT(RCC->AHB4ENR, 1 << port); }
 
 /**
- * @brief Power off the GPIO port hardware. 
+ * @brief Power off the GPIO port hardware.
  */
-void GPIOPort::deinit() {
-    CLEAR_BIT(RCC->AHB4ENR, 1 << port);
-}
+void GPIOPort::deinit() { CLEAR_BIT(RCC->AHB4ENR, 1 << port); }
 
 /**
  * @brief Configure a GPIO pin.
- * 
+ *
  * @param Pin mode.
  * @param Input/output/alternate as well as the push-pull/open drain mode.
  * @param res Pull-up/pull-down resistor configuration.
@@ -58,13 +61,11 @@ void GPIOPin::configure(Mode mode, Resistor res, uint32_t alt) {
 /**
  * @brief Rest the pin configuration.
  */
-void GPIOPin::reset() {
-    HAL_GPIO_DeInit(state.port.regs, state.pin);
-}
+void GPIOPin::reset() { HAL_GPIO_DeInit(state.port.regs, state.pin); }
 
 /**
  * @brief Write to a GPIO pin.
- * 
+ *
  * @param on true = HIGH, false = low
  */
 void GPIOPin::write(bool on) {
@@ -74,21 +75,13 @@ void GPIOPin::write(bool on) {
 /**
  * @brief Read from a GPIO pin.
  *
- * @return true = HIGH, false = LOW 
+ * @return true = HIGH, false = LOW
  */
-bool GPIOPin::read() {
-    return HAL_GPIO_ReadPin(state.port.regs, state.pin);
-}
+bool GPIOPin::read() { return HAL_GPIO_ReadPin(state.port.regs, state.pin); }
 
-HwOwner<GPIOPort>
-GPIO_A(GPIOPort::Port::A),
-GPIO_B(GPIOPort::Port::B),
-GPIO_C(GPIOPort::Port::C),
-GPIO_D(GPIOPort::Port::D),
-GPIO_E(GPIOPort::Port::E),
-GPIO_F(GPIOPort::Port::F),
-GPIO_G(GPIOPort::Port::G),
-GPIO_H(GPIOPort::Port::H),
-GPIO_I(GPIOPort::Port::I),
-GPIO_J(GPIOPort::Port::J),
-GPIO_K(GPIOPort::Port::K);
+HwOwner<GPIOPort> GPIO_A(GPIOPort::Port::A), GPIO_B(GPIOPort::Port::B),
+    GPIO_C(GPIOPort::Port::C), GPIO_D(GPIOPort::Port::D),
+    GPIO_E(GPIOPort::Port::E), GPIO_F(GPIOPort::Port::F),
+    GPIO_G(GPIOPort::Port::G), GPIO_H(GPIOPort::Port::H),
+    GPIO_I(GPIOPort::Port::I), GPIO_J(GPIOPort::Port::J),
+    GPIO_K(GPIOPort::Port::K);

--- a/src/hardware/gpio.h
+++ b/src/hardware/gpio.h
@@ -5,6 +5,8 @@
 #include "hardware/hardware.h"
 #include "hardware/hw_access.h"
 
+#include <array>
+
 class GPIOPort;
 
 /**
@@ -103,7 +105,7 @@ private:
     friend class GPIOPin;
 
     Port port;
-    GPIOPin::GPIOPinState pin_states[16];
+    std::array<GPIOPin::GPIOPinState, 16> pin_states;
     GPIO_TypeDef *regs;
 };
 

--- a/src/hardware/gpio.h
+++ b/src/hardware/gpio.h
@@ -21,10 +21,9 @@ class GPIOPort;
  */
 class GPIOPin {
 public:
-
     /**
      * @brief Type-safe mode selection.
-     * 
+     *
      * Technically, this combines both the "mode" field of the GPIO peripheral
      * with the "push-pull" field.
      */
@@ -52,29 +51,28 @@ public:
     void write(bool on);
     bool read();
 
-    GPIOPin(const GPIOPin& pin) = default;
-    GPIOPin& operator=(const GPIOPin& pin) = default;
+    GPIOPin(const GPIOPin &pin) = default;
+    GPIOPin &operator=(const GPIOPin &pin) = default;
 
 private:
-
     friend class GPIOPort;
 
     struct GPIOPinState {
 
-        GPIOPinState(GPIOPort& port, uint32_t pin): port(port), pin(1 << pin) {}
+        GPIOPinState(GPIOPort &port, uint32_t pin)
+            : port(port), pin(1 << pin) {}
 
-        const GPIOPort& port;
+        const GPIOPort &port;
         const uint32_t pin;
-        
+
         Mode mode;
         Resistor res;
         uint32_t alt;
     };
 
-    GPIOPin(GPIOPinState& state): state(state) {}
+    GPIOPin(GPIOPinState &state) : state(state) {}
 
-    GPIOPinState& state;
-
+    GPIOPinState &state;
 };
 
 /**
@@ -91,11 +89,10 @@ private:
  */
 class GPIOPort : public Hardware {
 public:
-
     enum Port { A = 0, B, C, D, E, F, G, H, I, J, K };
 
     GPIOPort(Port port);
-    GPIOPort(const GPIOPort& port) = delete;
+    GPIOPort(const GPIOPort &port) = delete;
 
     GPIOPin get_pin(uint32_t pin);
 
@@ -103,13 +100,12 @@ public:
     void deinit() override;
 
 private:
-
     friend class GPIOPin;
 
     Port port;
     GPIOPin::GPIOPinState pin_states[16];
     GPIO_TypeDef *regs;
-
 };
 
-extern HwOwner<GPIOPort> GPIO_A, GPIO_B, GPIO_C, GPIO_D, GPIO_E, GPIO_F, GPIO_G, GPIO_H, GPIO_I, GPIO_J, GPIO_K;
+extern HwOwner<GPIOPort> GPIO_A, GPIO_B, GPIO_C, GPIO_D, GPIO_E, GPIO_F, GPIO_G,
+    GPIO_H, GPIO_I, GPIO_J, GPIO_K;

--- a/src/hardware/hw_access.h
+++ b/src/hardware/hw_access.h
@@ -1,34 +1,29 @@
 #pragma once
 
-#include "hardware.h"
 #include "FreeRTOS.h"
+#include "hardware.h"
 #include "semphr.h"
 
-template<typename T>
-class HwAccess;
+template <typename T> class HwAccess;
 
-template<typename T>
-class HwOwner {
+template <typename T> class HwOwner {
 
 public:
-
     HwOwner();
-    template<class... Args>
-    HwOwner(Args&&... args);
+    template <class... Args> HwOwner(Args &&... args);
 
-    HwOwner(const HwOwner& o) = delete;
-    HwOwner& operator=(const HwOwner& o) = delete;
+    HwOwner(const HwOwner &o) = delete;
+    HwOwner &operator=(const HwOwner &o) = delete;
 
-    HwOwner(HwOwner&& o) = delete;
-    HwOwner& operator=(HwOwner&& o) = delete;
+    HwOwner(HwOwner &&o) = delete;
+    HwOwner &operator=(HwOwner &&o) = delete;
 
     HwAccess<T> get_access();
 
 private:
-
     friend class HwAccess<T>;
 
-    void remove_access(const HwAccess<T>& a);
+    void remove_access(const HwAccess<T> &a);
 
     T hw;
     uint32_t refcount;
@@ -36,13 +31,10 @@ private:
     StaticSemaphore_t refcount_mutex_buffer;
     SemaphoreHandle_t access_mutex;
     StaticSemaphore_t access_mutex_buffer;
-
 };
 
-template<typename T>
-class HwAccess {
+template <typename T> class HwAccess {
 public:
-
     void end();
 
     ~HwAccess() { end(); }
@@ -50,76 +42,71 @@ public:
     void get_exclusive();
     void release_exclusive();
 
-    T* operator->() { return &owner.hw; }
-    T& operator*() { return owner.hw; }
+    T *operator->() { return &owner.hw; }
+    T &operator*() { return owner.hw; }
 
 private:
-
     friend class HwOwner<T>;
 
-    HwAccess(HwOwner<T>& o): owner(o), exclusive(false) {}
+    HwAccess(HwOwner<T> &o) : owner(o), exclusive(false) {}
 
-    HwAccess(const HwAccess& s) = delete;
-    HwAccess& operator=(const HwAccess& s) = delete;
+    HwAccess(const HwAccess &s) = delete;
+    HwAccess &operator=(const HwAccess &s) = delete;
 
-    HwAccess(HwAccess&& s) = delete;
-    HwAccess& operator=(HwAccess&& s) = delete;
+    HwAccess(HwAccess &&s) = delete;
+    HwAccess &operator=(HwAccess &&s) = delete;
 
-    HwOwner<T>& owner;
+    HwOwner<T> &owner;
     bool exclusive;
-
 };
 
-template<typename T>
-inline HwOwner<T>::HwOwner() { 
+template <typename T> inline HwOwner<T>::HwOwner() {
     refcount = 0;
     refcount_mutex = xSemaphoreCreateMutexStatic(&refcount_mutex_buffer);
     access_mutex = xSemaphoreCreateRecursiveMutexStatic(&access_mutex_buffer);
 }
 
-template<typename T>
-template<class... Args>
-inline HwOwner<T>::HwOwner(Args&&... args): hw(args...) { 
+template <typename T>
+template <class... Args>
+inline HwOwner<T>::HwOwner(Args &&... args) : hw(args...) {
     refcount = 0;
     refcount_mutex = xSemaphoreCreateMutexStatic(&refcount_mutex_buffer);
     access_mutex = xSemaphoreCreateRecursiveMutexStatic(&access_mutex_buffer);
 }
 
-template<typename T>
-inline HwAccess<T> HwOwner<T>::get_access() {
-   xSemaphoreTake(refcount_mutex, portMAX_DELAY);
-   if (refcount == 0) {
-       hw.init();
-   }
-   ++refcount;
-   xSemaphoreGive(refcount_mutex);
-   return HwAccess(*this);
+template <typename T> inline HwAccess<T> HwOwner<T>::get_access() {
+    xSemaphoreTake(refcount_mutex, portMAX_DELAY);
+    if (refcount == 0) {
+        hw.init();
+    }
+    ++refcount;
+    xSemaphoreGive(refcount_mutex);
+    return HwAccess(*this);
 }
 
-template<typename T>
-inline void HwOwner<T>::remove_access(const HwAccess<T>& a) {
-   xSemaphoreTake(refcount_mutex, portMAX_DELAY);
-   --refcount;
-   if (refcount == 0) { hw.deinit(); }
-   xSemaphoreGive(refcount_mutex);
+template <typename T>
+inline void HwOwner<T>::remove_access(const HwAccess<T> &a) {
+    xSemaphoreTake(refcount_mutex, portMAX_DELAY);
+    --refcount;
+    if (refcount == 0) {
+        hw.deinit();
+    }
+    xSemaphoreGive(refcount_mutex);
 }
 
-template<typename T>
-inline void HwAccess<T>::end() {
-   owner.remove_access(*this);
-   if (exclusive) {
-       release_exclusive();
-   }
+template <typename T> inline void HwAccess<T>::end() {
+    owner.remove_access(*this);
+    if (exclusive) {
+        release_exclusive();
+    }
 }
 
-template<typename T>
-inline void HwAccess<T>::get_exclusive() {
-   xSemaphoreTakeRecursive(owner.access_mutex, portMAX_DELAY);
-   exclusive = true;
+template <typename T> inline void HwAccess<T>::get_exclusive() {
+    xSemaphoreTakeRecursive(owner.access_mutex, portMAX_DELAY);
+    exclusive = true;
 }
 
-template<typename T>
-inline void HwAccess<T>::release_exclusive() {
-   xSemaphoreGiveRecursive(owner.access_mutex);
-   exclusive = false;
+template <typename T> inline void HwAccess<T>::release_exclusive() {
+    xSemaphoreGiveRecursive(owner.access_mutex);
+    exclusive = false;
 }

--- a/src/hardware/random.h
+++ b/src/hardware/random.h
@@ -10,7 +10,6 @@
  */
 class Random : public Hardware {
 public:
-
     Random() { handle.Instance = RNG; }
 
     void init() override;
@@ -20,7 +19,6 @@ public:
 
 protected:
     RNG_HandleTypeDef handle; //< Handle to the hardware for secure rng.
-
 };
 
 extern HwOwner<Random> random_instance;

--- a/src/hardware/uart.cpp
+++ b/src/hardware/uart.cpp
@@ -13,13 +13,16 @@
  * @param tx The pin to transmit on.
  * @param rx The pin to receive on.
  */
-UART::UART(UART::Port port, uint32_t baud, HwOwner<GPIOPort>& gpio_port, uint8_t tx,
-           uint8_t rx)
-    : port(port), regs(uart_registers[port]), baud(baud), gpio_port_access(gpio_port.get_access()),
-      tx_pin(gpio_port_access->get_pin(tx)), rx_pin(gpio_port_access->get_pin(rx))
-{
-    tx_pin.configure(GPIOPin::Mode::AlternatePP, GPIOPin::Resistor::None, gpio_afs[port]);
-    rx_pin.configure(GPIOPin::Mode::AlternatePP, GPIOPin::Resistor::None, gpio_afs[port]);
+UART::UART(UART::Port port, uint32_t baud, HwOwner<GPIOPort> &gpio_port,
+           uint8_t tx, uint8_t rx)
+    : port(port), regs(uart_registers[port]), baud(baud),
+      gpio_port_access(gpio_port.get_access()),
+      tx_pin(gpio_port_access->get_pin(tx)),
+      rx_pin(gpio_port_access->get_pin(rx)) {
+    tx_pin.configure(GPIOPin::Mode::AlternatePP, GPIOPin::Resistor::None,
+                     gpio_afs[port]);
+    rx_pin.configure(GPIOPin::Mode::AlternatePP, GPIOPin::Resistor::None,
+                     gpio_afs[port]);
     uarts[port] = this;
 }
 

--- a/src/hardware/uart.h
+++ b/src/hardware/uart.h
@@ -61,7 +61,8 @@ public:
         ERROR_UNKNOWN,
     };
 
-    UART(Port port, uint32_t baud, HwOwner<GPIOPort>& gpio_port, uint8_t tx, uint8_t rx);
+    UART(Port port, uint32_t baud, HwOwner<GPIOPort> &gpio_port, uint8_t tx,
+         uint8_t rx);
 
     void init() override;
     void deinit() override;

--- a/src/startup/main.cpp
+++ b/src/startup/main.cpp
@@ -1,7 +1,7 @@
 #include "hardware/clock.h"
+#include "hardware/gpio.h"
 #include "hardware/init.h"
 #include "hardware/uart.h"
-#include "hardware/gpio.h"
 #include "os/os.h"
 
 UART uart{UART::U3, 9600, GPIO_D, 8, 9};

--- a/src/startup/main.cpp
+++ b/src/startup/main.cpp
@@ -46,7 +46,7 @@ int main() {
  */
 void init_func() {
     uart.init();
-    
+
     pin.configure(GPIOPin::Mode::OutputPP, GPIOPin::Resistor::None, 0);
     for (int i = 0; i < 3; i++) {
         vTaskDelay(1000);

--- a/src/util/crypto.cpp
+++ b/src/util/crypto.cpp
@@ -4,33 +4,28 @@
 #include "prandom.h"
 #include <hydrogen.h>
 
-static const char* CONTEXT = "General";
+static const char *CONTEXT = "General";
 const size_t CRYPTO_KEY_SIZE = hydro_secretbox_KEYBYTES;
 const size_t CRYPTO_HEADER_SIZE = hydro_secretbox_HEADERBYTES;
 const int CRYPTO_SUCCESS = 0;
 const int CRYPTO_MESSAGE_FORGED = 1;
 
-void crypto_init(Random &random) {
-    PRandom prandom(random);
-}
+void crypto_init(Random &random) { PRandom prandom(random); }
 
-void key_generate(void *key) {
-    hydro_secretbox_keygen((uint8_t*)key);
-}
+void key_generate(void *key) { hydro_secretbox_keygen((uint8_t *)key); }
 
-int encrypt(const void *plain, const size_t plain_bytes, const void *key, 
-               void *encrypted, const uint64_t msg_id)
-{
-    hydro_secretbox_encrypt((uint8_t*)encrypted, plain, plain_bytes, 
-                            msg_id, CONTEXT, (const uint8_t*)key);
+int encrypt(const void *plain, const size_t plain_bytes, const void *key,
+            void *encrypted, const uint64_t msg_id) {
+    hydro_secretbox_encrypt((uint8_t *)encrypted, plain, plain_bytes, msg_id,
+                            CONTEXT, (const uint8_t *)key);
     return CRYPTO_SUCCESS;
 }
 
-int decrypt(const void *encrypted, const size_t encrypted_bytes, const void *key,
-               void *plain, const uint64_t msg_id)
-{
-    if (hydro_secretbox_decrypt(plain, (const uint8_t*)encrypted, encrypted_bytes, 
-                                msg_id, CONTEXT, (const uint8_t*)key) != 0) {
+int decrypt(const void *encrypted, const size_t encrypted_bytes,
+            const void *key, void *plain, const uint64_t msg_id) {
+    if (hydro_secretbox_decrypt(plain, (const uint8_t *)encrypted,
+                                encrypted_bytes, msg_id, CONTEXT,
+                                (const uint8_t *)key) != 0) {
         return CRYPTO_MESSAGE_FORGED;
     }
     return CRYPTO_SUCCESS;

--- a/src/util/crypto.h
+++ b/src/util/crypto.h
@@ -46,14 +46,15 @@ void key_generate(void *key);
  * @param plain_bytes Size of plain data in bytes.
  * @param key Pointer to key data.
  * @param encrypted Pointer to a buffer to write encrypted message to.
- *        The size of encrypted buffer should equal to plain_bytes + HEADER_SIZE.
+ *        The size of encrypted buffer should equal to plain_bytes +
+ * HEADER_SIZE.
  * @param msg_id Optional user purpose message id.
- * 
+ *
  * @return Return success code of the operation.
  */
 int encrypt(const void *plain, const size_t plain_bytes, const void *key,
             void *encrypted, const uint64_t msg_id = 0);
-            
+
 /**
  * @brief Decrypt a message.
  *
@@ -61,10 +62,11 @@ int encrypt(const void *plain, const size_t plain_bytes, const void *key,
  * @param encrypted_bytes Size of encrypted data in bytes.
  * @param key Pointer to key data.
  * @param plain Pointer to a buffer to write decrypted message to.
- *        The size of decrypted buffer should equal to encrypted_bytes - HEADER_SIZE.
+ *        The size of decrypted buffer should equal to encrypted_bytes -
+ * HEADER_SIZE.
  * @param msg_id Optional expected message id.
- * 
+ *
  * @return Return success code of the operation.
  */
-int decrypt(const void *encrypted, const size_t encrypted_bytes, const void *key,
-            void *plain, const uint64_t msg_id = 0);
+int decrypt(const void *encrypted, const size_t encrypted_bytes,
+            const void *key, void *plain, const uint64_t msg_id = 0);

--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -15,7 +15,7 @@ void debug_msg(const char *msg) {
             "mov r0, #0x4;"
             "bkpt #0xab;"
             :
-            : [msg] "r"(msg));
+            : [ msg ] "r"(msg));
 #endif
 }
 

--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -15,7 +15,7 @@ void debug_msg(const char *msg) {
             "mov r0, #0x4;"
             "bkpt #0xab;"
             :
-            : [ msg ] "r"(msg));
+            : [msg] "r"(msg));
 #endif
 }
 

--- a/src/util/i2a.cpp
+++ b/src/util/i2a.cpp
@@ -1,19 +1,23 @@
 #include "i2a.h"
 
-char* i2a(int i) {
+char *i2a(int i) {
     static char buf[1024];
     buf[1023] = '\0';
-    char* start = buf;
+    char *start = buf;
 
     bool neg = i < 0;
-    if (neg) { i = -i; }
+    if (neg) {
+        i = -i;
+    }
 
     while (i != 0) {
         *(--start) = '0' + (i % 10);
         i /= 10;
     }
 
-    if (neg) { *(--start) = '-'; }
+    if (neg) {
+        *(--start) = '-';
+    }
 
     return start;
 }

--- a/src/util/i2a.h
+++ b/src/util/i2a.h
@@ -1,3 +1,3 @@
 #pragma once
 
-char* i2a(int i);
+char *i2a(int i);

--- a/src/util/prandom.cpp
+++ b/src/util/prandom.cpp
@@ -7,11 +7,9 @@ PRandom::PRandom(Random &random) {
         uint32_t seed = random();
 
         if (hydro_init_buffer_counter < HYDRO_INIT_BUFFER_SIZE) {
-            for (
-              size_t i = 0;
-              i < sizeof(seed) && hydro_init_buffer_counter < HYDRO_INIT_BUFFER_SIZE;
-              i++, hydro_init_buffer_counter++
-            ) {
+            for (size_t i = 0; i < sizeof(seed) && hydro_init_buffer_counter <
+                                                       HYDRO_INIT_BUFFER_SIZE;
+                 i++, hydro_init_buffer_counter++) {
                 hydro_init_buffer[hydro_init_buffer_counter] = seed & 0xFF;
                 seed >>= sizeof(uint8_t);
             }
@@ -30,6 +28,4 @@ uint32_t PRandom::fast() {
     return twister();
 }
 
-uint32_t PRandom::secure() {
-    return hydro_random_u32();
-}
+uint32_t PRandom::secure() { return hydro_random_u32(); }

--- a/src/util/prandom.cpp
+++ b/src/util/prandom.cpp
@@ -20,12 +20,8 @@ PRandom::PRandom(Random &random) {
     }
 }
 
-PRandom::PRandom(PRandom &prandom) {
-    twister.seed(prandom.secure());
-}
+PRandom::PRandom(PRandom &prandom) { twister.seed(prandom.secure()); }
 
-uint32_t PRandom::fast() {
-    return twister();
-}
+uint32_t PRandom::fast() { return twister(); }
 
 uint32_t PRandom::secure() { return hydro_random_u32(); }

--- a/src/util/prandom.h
+++ b/src/util/prandom.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <random>
 #include "hardware/random.h"
+#include <random>
 
 class PRandom {
 public:
-
     PRandom(Random &random);
     PRandom(PRandom &prandom);
 


### PR DESCRIPTION
Runs a few basic checks on the repository from CI: First, it checks for build warnings with GCC (our release configuration), then it lints with cppcheck, diffs the styling with clang-format, and then runs the clang static analyzer (this is still experimental).

Finally, there's a python script that runs that scans the codebase (in a rather fragile way for now) for task declarations, extracts their start functions and the amount of static stack allocated to them, and then verifies that the function's used stack will always be less than the allocated stack (using gcc's `-fstack-usage` flag).

The summary printed in the CI builds looks like:
```
task            allocated           used
----------------------------------------
init_task             512             16
```

Run `python3 scripts/task_stack.py` to get this report on your local machine.