### PR TITLE
Various build system and static analysis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ addons:
       - python3
 script:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
+  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
   - sudo apt-get update -q
-  - sudo apt-get install gcc-arm-embedded -y
+  - sudo apt-get install --yes --no-install-recommends clang-format-8 clang-tidy-8 gcc-arm-embedded
+  - sudo ln -s clang-format-8 /usr/bin/clang-format
+  - sudo ln -s clang-tidy-8 /usr/bin/clang-tidy
   - arm-none-eabi-gcc --version
   - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake -G "Ninja"
   - ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
   - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
   - sudo apt-get update -q
   - sudo apt-get install --yes --no-install-recommends clang-format-8 clang-tidy-8 gcc-arm-embedded
-  - sudo ln -s clang-format-8 /usr/bin/clang-format
-  - sudo ln -s clang-tidy-8 /usr/bin/clang-tidy
+  - sudo ln -sf clang-format-8 /usr/bin/clang-format
+  - sudo ln -sf clang-tidy-8 /usr/bin/clang-tidy
   - arm-none-eabi-gcc --version
   - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake -G "Ninja"
   - ninja

--- a/analyze.sh
+++ b/analyze.sh
@@ -10,4 +10,5 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
       -DCMAKE_TOOLCHAIN_FILE=./cmake/static.cmake -G Ninja .
 
 # run the linter
-clang-tidy -system-headers -header-filter='.*' src/**/*.cpp src/**/*.h
+clang-tidy-8 --version
+clang-tidy-8 -header-filter='.*' src/**/*.cpp src/**/*.h

--- a/analyze.sh
+++ b/analyze.sh
@@ -10,4 +10,4 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
       -DCMAKE_TOOLCHAIN_FILE=./cmake/static.cmake -G Ninja .
 
 # run the linter
-clang-tidy src/**/*.cpp
+clang-tidy -system-headers -header-filter='.*' src/**/*.cpp src/**/*.h

--- a/boot.sh
+++ b/boot.sh
@@ -3,4 +3,4 @@
 # run cmake, point it towards the toolchain file, and emit a
 # compile_commands.json for use with clang autocompletion tooling
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1\
-      -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake $1 .
+      -DCMAKE_TOOLCHAIN_FILE=./cmake/gcc.cmake -G Ninja "$@" .

--- a/cmake/static.cmake
+++ b/cmake/static.cmake
@@ -13,8 +13,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-include_directories("/usr/arm-none-eabi/include/c++/7.3.1")
-include_directories("/usr/arm-none-eabi/include/c++/7.3.1/arm-none-eabi")
+file(GLOB GCC_INCLUDES /usr/arm-none-eabi/include/c++/*/ /usr/arm-none-eabi/include/c++/*/arm-none-eabi)
+include_directories(${GCC_INCLUDES})
 
 set(FLAGS_COMMON "-target armv7em-none-eabihf -I/usr/arm-none-eabi/include" CACHE INTERNAL "C / C++ common Flags")
 set(FLAGS_CXX "-std=c++17 -Wno-register -fno-unwind-tables -fno-exceptions -fno-rtti" CACHE INTERNAL "C++ only Flags")


### PR DESCRIPTION
- Get lints from headers, too
- Use ninja by default on linux
- Parse ALL command line arguments passed to ./boot.sh
- Use GLOB to find GCC include directories, so that it works on all
- versions of GCC