### PR TITLE
Add warning to prevent accidentally ignoring Async promise.

### DIFF
--- a/src/hardware/uart.h
+++ b/src/hardware/uart.h
@@ -66,10 +66,10 @@ public:
     void init() override;
     void deinit() override;
 
-    Async<Status> transmit(const uint8_t *, size_t len);
-    Async<Status> transmit(const char *);
+    CHECK Async<Status> transmit(const uint8_t *, size_t len);
+    CHECK Async<Status> transmit(const char *);
 
-    Async<Status> receive(uint8_t *data, size_t len);
+    CHECK Async<Status> receive(uint8_t *data, size_t len);
 
 protected:
     Port port;                 //< The UART we own.

--- a/src/os/async.h
+++ b/src/os/async.h
@@ -6,6 +6,7 @@
 #include <queue.h>
 
 #define FWD(...) ::std::forward<decltype(__VA_ARGS__)>(__VA_ARGS__)
+#define CHECK __attribute__((warn_unused_result))
 
 /**
  * @brief Helper class that is an @ref Async that has been mapped or


### PR DESCRIPTION
Now, if you make the common mistake of using an async-returning function without blocking (or otherwise using it), you get a compiler warning.